### PR TITLE
jsonToNoiseParams: Accept any number, instead of only doubles

### DIFF
--- a/src/eu/jacobsjo/multinoisevis/MultiNoiseStringBiomeSource.java
+++ b/src/eu/jacobsjo/multinoisevis/MultiNoiseStringBiomeSource.java
@@ -134,7 +134,7 @@ public class MultiNoiseStringBiomeSource {
         JSONArray amplitudes = obj.getJSONArray("amplitudes");
         ArrayList<Double> amp = new ArrayList<>();
         for (Object a : amplitudes){
-            amp.add((Double) a);
+            amp.add(((Number) a).doubleValue());
         }
 
         int firstOctave = obj.getInt("firstOctave");


### PR DESCRIPTION
This fixes a bug where non-double values in noise parameters would not
correctly be cast to a double.

Instead of casting to double directly, I cast to Number and take the
double value now.

This fixes #1