### PR TITLE
gradle: Make prodJar task work on other systems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ task prodJar(type: ProGuardTask) {
     dependsOn jar
     injars jar.archivePath
     outjars buildDir.getPath() + '/prod/MinecraftMultiNoiseVisualization/MinecraftMultiNoiseVisualization-' + project.version + '.jar'
-    libraryjars(configurations.compile + configurations.compileOnly + files('/usr/lib/jvm/java-8-openjdk/jre/lib/rt.jar'))
+    libraryjars(configurations.compile + configurations.compileOnly + files("${System.getProperty('java.home')}/lib/rt.jar"))
     applymapping 'minecraft-server-jars/server.txt'
     keep 'class *'
     keep 'class eu.jacobsjo.multinoisevis.Main{ public static void main(java.lang.String[]); }'


### PR DESCRIPTION
Before, the prodJar task was hardcoded to use `/usr/lib/jvm/java-8-openjdk/jre/lib/rt.jar`.
This may work on systems using that path, but it will not work on e.g. Windows, even if openjdk 8 is installed.

This changes that to use the more generic `System.getProperty('java.home')`.